### PR TITLE
Add a method to print the operation env in deploy command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.7
+          go-version: ^1.16
         id: go
 
       - name: Configure git for private modules
@@ -43,4 +43,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37.1
+          version: v1.45

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: 1.17.7
         id: go
 
       - name: Configure git for private modules

--- a/internal/pkg/printer/common.go
+++ b/internal/pkg/printer/common.go
@@ -18,6 +18,7 @@ package printer
 
 import (
 	"fmt"
+
 	"github.com/napptive/nerrors/pkg/nerrors"
 	"github.com/rs/zerolog"
 )
@@ -29,6 +30,9 @@ type ResultPrinter interface {
 	Print(result interface{}) error
 	// PrintResultOrError prints the result using a given printer or the error.
 	PrintResultOrError(result interface{}, err error) error
+	// PrintResultOrErrorWithExtendedHeader prints the result indicating the environment where the user is logged
+	// and the environment where the user is operating
+	PrintResultOrErrorWithExtendedHeader(result interface{}, opEnv string, err error) error
 }
 
 // GetPrinter creates a ResultPrinter attending to the user preferences.

--- a/internal/pkg/printer/json.go
+++ b/internal/pkg/printer/json.go
@@ -43,3 +43,7 @@ func (jp *JSONPrinter) Print(result interface{}) error {
 func (jp *JSONPrinter) PrintResultOrError(result interface{}, err error) error {
 	return PrintResultOrError(jp, result, err)
 }
+
+func (jp *JSONPrinter) PrintResultOrErrorWithExtendedHeader(result interface{}, opEnv string, err error) error {
+	return PrintResultOrError(jp, result, err)
+}

--- a/internal/pkg/printer/noprinter.go
+++ b/internal/pkg/printer/noprinter.go
@@ -34,3 +34,7 @@ func (jp *NoPrinter) Print(result interface{}) error {
 func (jp *NoPrinter) PrintResultOrError(result interface{}, err error) error {
 	return err
 }
+
+func (jp *NoPrinter) PrintResultOrErrorWithExtendedHeader(result interface{}, opEnv string, err error) error {
+	return err
+}

--- a/internal/pkg/printer/table.go
+++ b/internal/pkg/printer/table.go
@@ -18,10 +18,11 @@ package printer
 
 import (
 	"fmt"
-	grpc_catalog_go "github.com/napptive/grpc-catalog-go"
 	"os"
 	"text/tabwriter"
 	"text/template"
+
+	grpc_catalog_go "github.com/napptive/grpc-catalog-go"
 
 	"github.com/napptive/nerrors/pkg/nerrors"
 )
@@ -87,5 +88,13 @@ func (tp *TablePrinter) Print(result interface{}) error {
 
 // PrintResultOrError prints the result using a given printer or the error.
 func (tp *TablePrinter) PrintResultOrError(result interface{}, err error) error {
+	return PrintResultOrError(tp, result, err)
+}
+
+func (tp *TablePrinter) PrintResultOrErrorWithExtendedHeader(result interface{}, opEnv string, err error) error {
+
+	if err == nil && opEnv != "" {
+		fmt.Println(fmt.Sprintf("Operation environment: %s", opEnv))
+	}
 	return PrintResultOrError(tp, result, err)
 }

--- a/internal/pkg/printer/table.go
+++ b/internal/pkg/printer/table.go
@@ -94,7 +94,7 @@ func (tp *TablePrinter) PrintResultOrError(result interface{}, err error) error 
 func (tp *TablePrinter) PrintResultOrErrorWithExtendedHeader(result interface{}, opEnv string, err error) error {
 
 	if err == nil && opEnv != "" {
-		fmt.Println(fmt.Sprintf("Operation environment: %s", opEnv))
+		fmt.Println(fmt.Sprintf("Operating environment: %s", opEnv))
 	}
 	return PrintResultOrError(tp, result, err)
 }

--- a/internal/pkg/printer/table.go
+++ b/internal/pkg/printer/table.go
@@ -94,7 +94,7 @@ func (tp *TablePrinter) PrintResultOrError(result interface{}, err error) error 
 func (tp *TablePrinter) PrintResultOrErrorWithExtendedHeader(result interface{}, opEnv string, err error) error {
 
 	if err == nil && opEnv != "" {
-		fmt.Println(fmt.Sprintf("Operating environment: %s", opEnv))
+		fmt.Printf("Operating environment: %s\n", opEnv)
 	}
 	return PrintResultOrError(tp, result, err)
 }

--- a/pkg/catalog/operations/deploy.go
+++ b/pkg/catalog/operations/deploy.go
@@ -65,5 +65,5 @@ func (d *Deploy) Deploy(applicationID string, targetEnvQualifiedName string, tar
 		TargetEnvironmentQualifiedName: targetEnvQualifiedName,
 		TargetPlaygroundApiUrl:         targetPlaygroundAPI,
 	})
-	return d.ResultPrinter.PrintResultOrError(response, err)
+	return d.ResultPrinter.PrintResultOrErrorWithExtendedHeader(response, targetEnvQualifiedName, err)
 }


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README/documentation, if necessary

#### What does this PR do?
Adds a new method in the printer to print the operating environment when deploying an application.
A user can be logged in to an environment and deploy an application in another one. It should be interesting to should the operating environment 

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the associated tickets?

#### Screenshots (if appropriate)

#### Questions
