### PR TITLE
Implement `search` command

### DIFF
--- a/cmd/catalog/commands/catalog.go
+++ b/cmd/catalog/commands/catalog.go
@@ -105,7 +105,29 @@ var listCmd = &cobra.Command{
 		if len(args) == 1 {
 			targetNamespace = args[0]
 		}
-		crashOnError(catalog.List(targetNamespace))
+		crashOnError(catalog.List(targetNamespace, ""))
+	},
+}
+
+var catalogSearchCmdLongHelp = `Search for applications by name stored in the catalog`
+
+var catalogSearchCmdShortHelp = `Search for applications`
+
+var targetNamespace = ""
+
+var searchCmd = &cobra.Command{
+	Use:   "search [application Name]",
+	Long:  catalogSearchCmdLongHelp,
+	Short: catalogSearchCmdShortHelp,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		catalog, err := operations.NewCatalog(&cfg)
+		crashOnError(err)
+		searchString := ""
+		if len(args) == 1 {
+			searchString = args[0]
+		}
+		crashOnError(catalog.List(targetNamespace, searchString))
 	},
 }
 
@@ -162,6 +184,8 @@ func init() {
 
 	pushCmd.Flags().BoolVar(&privateApp, "private", false, "Flag to indicate if an application is private")
 
+	searchCmd.Flags().StringVarP(&targetNamespace, "namespace", "n", "", "Namespace to search for applications")
+
 	catalogChangeVisibilityCmd.Flags().BoolVar(&privateApp, "private", false, "Flag to indicate if an application becomes private")
 	catalogChangeVisibilityCmd.Flags().BoolVar(&publicApp, "public", true, "Flag to indicate if an application becomes public")
 
@@ -172,4 +196,5 @@ func init() {
 	rootCmd.AddCommand(summaryCmd)
 	rootCmd.AddCommand(catalogChangeVisibilityCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(searchCmd)
 }

--- a/cmd/catalog/commands/catalog.go
+++ b/cmd/catalog/commands/catalog.go
@@ -123,10 +123,7 @@ var searchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		catalog, err := operations.NewCatalog(&cfg)
 		crashOnError(err)
-		searchString := ""
-		if len(args) == 1 {
-			searchString = args[0]
-		}
+		searchString := args[0]
 		crashOnError(catalog.List(targetNamespace, searchString))
 	},
 }

--- a/pkg/catalog/operations/catalog.go
+++ b/pkg/catalog/operations/catalog.go
@@ -260,7 +260,7 @@ func (c *Catalog) List(targetNamespace string, searchString string) error {
 	})
 
 	if searchString != "" {
-		filter(response, searchString)
+		filterByName(response, searchString)
 	}
 
 	if err != nil {
@@ -269,7 +269,7 @@ func (c *Catalog) List(targetNamespace string, searchString string) error {
 	return c.ResultPrinter.PrintResultOrError(response, nil)
 }
 
-func filter(response *grpc_catalog_go.ApplicationList, searchString string) {
+func filterByName(response *grpc_catalog_go.ApplicationList, searchString string) {
 	var filtered []*grpc_catalog_go.ApplicationSummary
 	for _, app := range response.Applications {
 		if strings.Contains(app.ApplicationName, searchString) {


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README/documentation, if necessary. 
README will be updated through #40 

#### What does this PR do?
Add search functionality to the calalog cli. That will search for applications with provided name. 

